### PR TITLE
Togglable config download on mod download

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.mineinabyss
-version=1.0.2
+version=1.0.3
 idofrontConventions=1.6.10-51
 kotlinVersion=1.6.10

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
@@ -13,6 +13,7 @@ data class Config(
     val minecraftDir: String? = null,
     val fullEnabledGroups: Set<GroupName> = setOf(),
     val toggledMods: Set<ModName> = setOf(),
+    val toggledConfigs: Set<ModName> = setOf(),
     val downloads: Map<ModName, DownloadURL> = mapOf(),
     val seenGroups: Set<GroupName> = setOf(),
     val installedFabricVersion: String? = null,

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
@@ -1,11 +1,9 @@
 package com.mineinabyss.launchy.data
 
-import com.mineinabyss.launchy.logic.Downloader
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import java.io.*
 import java.util.zip.ZipFile
-import kotlin.io.path.div
 import kotlin.io.path.inputStream
 import kotlin.io.path.writeText
 
@@ -64,7 +62,3 @@ fun extractFile(inputStream: InputStream, destFilePath: String) {
     buffer.close()
 }
 
-suspend fun downloadConfig() {
-    val configUrl = "https://github.com/MineInAbyss/launchy-mods/releases/download/v1.0.0/configs.zip"
-    Downloader.download(configUrl, Dirs.mineinabyss / "configs.zip")
-}

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
@@ -66,5 +66,5 @@ fun extractFile(inputStream: InputStream, destFilePath: String) {
 
 suspend fun downloadConfig() {
     val configUrl = "https://github.com/MineInAbyss/launchy-mods/releases/download/v1.0.0/configs.zip"
-    Downloader.download(configUrl, Dirs.minecraft / "configs.zip")
+    Downloader.download(configUrl, Dirs.mineinabyss / "configs.zip")
 }

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Config.kt
@@ -1,9 +1,14 @@
 package com.mineinabyss.launchy.data
 
+import com.mineinabyss.launchy.logic.Downloader
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
+import java.io.*
+import java.util.zip.ZipFile
+import kotlin.io.path.div
 import kotlin.io.path.inputStream
 import kotlin.io.path.writeText
+
 
 @Serializable
 data class Config(
@@ -24,4 +29,42 @@ data class Config(
             Formats.yaml.decodeFromStream(serializer(), Dirs.configFile.inputStream())
         }.getOrDefault(Config())
     }
+}
+
+@Throws(IOException::class)
+fun unzip(zipFilePath: File, destDirectory: String) {
+
+    File(destDirectory).run {
+        if (!exists()) {
+            mkdirs()
+        }
+    }
+
+    ZipFile(zipFilePath).use { zip ->
+        zip.entries().asSequence().forEach { entry ->
+            zip.getInputStream(entry).use { input ->
+                val filePath = destDirectory + File.separator + entry.name
+
+                if (!entry.isDirectory) extractFile(input, filePath)
+                else File(filePath).mkdir()
+            }
+        }
+    }
+}
+
+@Throws(IOException::class)
+fun extractFile(inputStream: InputStream, destFilePath: String) {
+    val bufferSize = 4096
+    val buffer = BufferedOutputStream(FileOutputStream(destFilePath))
+    val bytes = ByteArray(bufferSize)
+    var read: Int
+    while (inputStream.read(bytes).also { read = it } != -1) {
+        buffer.write(bytes, 0, read)
+    }
+    buffer.close()
+}
+
+suspend fun downloadConfig() {
+    val configUrl = "https://github.com/MineInAbyss/launchy-mods/releases/download/v1.0.0/configs.zip"
+    Downloader.download(configUrl, Dirs.minecraft / "configs.zip")
 }

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Dirs.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Dirs.kt
@@ -1,10 +1,6 @@
 package com.mineinabyss.launchy.data
 
-import com.mineinabyss.launchy.logic.FabricInstaller
 import com.mineinabyss.launchy.util.OS
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import kotlin.io.path.*
 
 object Dirs {
@@ -21,6 +17,7 @@ object Dirs {
         OS.LINUX -> Path(System.getProperty("user.home")) / ".mineinabyss"
     }
     val mods = mineinabyss / "mods"
+    val configZip = mineinabyss / "configs.zip"
 
     val config = when (OS.get()) {
         OS.WINDOWS -> Path(System.getenv("APPDATA"))
@@ -31,13 +28,9 @@ object Dirs {
     val configFile = config / "mia-launcher.yml"
     val versionsFile = config / "mia-versions.yml"
 
-    @OptIn(DelicateCoroutinesApi::class)
     fun createDirs() {
         config.createDirectories()
-        if (mineinabyss.notExists()) {
-            mineinabyss.createDirectories()
-            GlobalScope.launch { FabricInstaller.installBaseConfigs() }
-        }
+        mineinabyss.createDirectories()
     }
 
     fun createConfigFiles() {

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Dirs.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Dirs.kt
@@ -1,6 +1,10 @@
 package com.mineinabyss.launchy.data
 
+import com.mineinabyss.launchy.logic.FabricInstaller
 import com.mineinabyss.launchy.util.OS
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlin.io.path.*
 
 object Dirs {
@@ -27,9 +31,13 @@ object Dirs {
     val configFile = config / "mia-launcher.yml"
     val versionsFile = config / "mia-versions.yml"
 
+    @OptIn(DelicateCoroutinesApi::class)
     fun createDirs() {
         config.createDirectories()
-        mineinabyss.createDirectories()
+        if (mineinabyss.notExists()) {
+            mineinabyss.createDirectories()
+            GlobalScope.launch { FabricInstaller.installBaseConfigs() }
+        }
     }
 
     fun createConfigFiles() {

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Mod.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Mod.kt
@@ -10,4 +10,5 @@ data class Mod(
     val desc: String,
     val url: String,
     val configUrl: String? = null,
+    val forceConfigDownload: Boolean = false,
 )

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Mod.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Mod.kt
@@ -9,4 +9,5 @@ data class Mod(
     val homepage: String? = null,
     val desc: String,
     val url: String,
+    val configUrl: String? = null,
 )

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
@@ -33,7 +33,7 @@ object FabricInstaller {
         return profiles.has(name)
     }
 
-    suspend fun installToLauncher(
+    fun installToLauncher(
         vanillaGameDir: Path,
         instanceDir: Path,
         profileName: String,
@@ -83,7 +83,7 @@ object FabricInstaller {
         (Dirs.mineinabyss / "configs.zip").toFile().delete()
     }
 
-    private suspend fun installProfile(
+    private fun installProfile(
         mcDir: Path,
         instanceDir: Path,
         profileName: String,
@@ -124,8 +124,6 @@ object FabricInstaller {
         profiles.put(foundProfileName, profile)
         jsonObject.put("profiles", profiles)
         Utils.writeToFile(launcherProfiles, jsonObject.toString())
-
-        installBaseConfigs()
     }
 
     private fun createProfile(name: String, instanceDir: Path, versionId: String): JSONObject {

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
@@ -6,9 +6,6 @@
  */
 package com.mineinabyss.launchy.logic
 
-import com.mineinabyss.launchy.data.Dirs
-import com.mineinabyss.launchy.data.downloadConfig
-import com.mineinabyss.launchy.data.unzip
 import mjson.Json
 import mjson.Json.read
 import net.fabricmc.installer.client.ProfileInstaller
@@ -23,7 +20,6 @@ import java.nio.file.Path
 import java.util.*
 import java.util.stream.Collectors
 import javax.swing.JOptionPane
-import kotlin.io.path.div
 
 object FabricInstaller {
     fun isProfileInstalled(mcDir: Path, name: String): Boolean {
@@ -75,12 +71,6 @@ object FabricInstaller {
         )
         val profileJson: Json = read(profileUrl)
         Utils.writeToFile(profileJsonPath, profileJson.toString())
-    }
-
-    suspend fun installBaseConfigs() {
-        downloadConfig()
-        unzip((Dirs.mineinabyss / "configs.zip").toFile(), Dirs.mineinabyss.toString())
-        (Dirs.mineinabyss / "configs.zip").toFile().delete()
     }
 
     private fun installProfile(

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
@@ -79,8 +79,8 @@ object FabricInstaller {
 
     suspend fun installBaseConfigs() {
         downloadConfig()
-        unzip((Dirs.minecraft / "configs.zip").toFile(), Dirs.minecraft.toString())
-        (Dirs.minecraft / "configs.zip").toFile().delete()
+        unzip((Dirs.mineinabyss / "configs.zip").toFile(), Dirs.mineinabyss.toString())
+        (Dirs.mineinabyss / "configs.zip").toFile().delete()
     }
 
     private suspend fun installProfile(

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/FabricInstaller.kt
@@ -6,6 +6,9 @@
  */
 package com.mineinabyss.launchy.logic
 
+import com.mineinabyss.launchy.data.Dirs
+import com.mineinabyss.launchy.data.downloadConfig
+import com.mineinabyss.launchy.data.unzip
 import mjson.Json
 import mjson.Json.read
 import net.fabricmc.installer.client.ProfileInstaller
@@ -20,6 +23,7 @@ import java.nio.file.Path
 import java.util.*
 import java.util.stream.Collectors
 import javax.swing.JOptionPane
+import kotlin.io.path.div
 
 object FabricInstaller {
     fun isProfileInstalled(mcDir: Path, name: String): Boolean {
@@ -28,7 +32,8 @@ object FabricInstaller {
         val profiles: JSONObject = jsonObject.getJSONObject("profiles")
         return profiles.has(name)
     }
-    fun installToLauncher(
+
+    suspend fun installToLauncher(
         vanillaGameDir: Path,
         instanceDir: Path,
         profileName: String,
@@ -72,7 +77,13 @@ object FabricInstaller {
         Utils.writeToFile(profileJsonPath, profileJson.toString())
     }
 
-    private fun installProfile(
+    suspend fun installBaseConfigs() {
+        downloadConfig()
+        unzip((Dirs.minecraft / "configs.zip").toFile(), Dirs.minecraft.toString())
+        (Dirs.minecraft / "configs.zip").toFile().delete()
+    }
+
+    private suspend fun installProfile(
         mcDir: Path,
         instanceDir: Path,
         profileName: String,
@@ -113,6 +124,8 @@ object FabricInstaller {
         profiles.put(foundProfileName, profile)
         jsonObject.put("profiles", profiles)
         Utils.writeToFile(launcherProfiles, jsonObject.toString())
+
+        installBaseConfigs()
     }
 
     private fun createProfile(name: String, instanceDir: Path, versionId: String): JSONObject {

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
@@ -94,7 +94,7 @@ class LaunchyState(
         }
     }
 
-    suspend fun installFabric() {
+    fun installFabric() {
         installingProfile = true
         FabricInstaller.installToLauncher(
             Dirs.minecraft,

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
@@ -56,6 +56,7 @@ class LaunchyState(
         updateNotPresent()
     }
 
+
     val upToDate: Set<Mod> by derivedStateOf {
         (downloadURLs - notPresentDownloads).filter { (mod, url) -> mod.url == url }.keys
     }
@@ -66,8 +67,17 @@ class LaunchyState(
     private var _deleted by mutableStateOf(0)
     val queuedDeletions by derivedStateOf {
         _deleted
-        disabledMods.filter { it.isDownloaded }.also { if(it.isEmpty()) updateNotPresent() }
+        disabledMods.filter { it.isDownloaded }.also { if (it.isEmpty()) updateNotPresent() }
     }
+
+    var notPresentConfigDownloads by mutableStateOf(setOf<Mod>())
+        private set
+
+    init {
+        configUpdateNotPresent()
+    }
+
+    var configToggleState = true
 
     val downloading = mutableStateMapOf<Mod, Long>()
     val isDownloading by derivedStateOf { downloading.isNotEmpty() }
@@ -125,7 +135,7 @@ class LaunchyState(
             downloadURLs[mod] = mod.url
             save()
 
-            if (mod.configUrl != null) {
+            if (mod.configUrl != null && configToggleState) {
                 Downloader.download(url = mod.configUrl, writeTo = Dirs.configZip)
                 downloadConfigURLs[mod] = mod.configUrl
                 unzip((Dirs.configZip).toFile(), Dirs.mineinabyss.toString())
@@ -158,6 +168,10 @@ class LaunchyState(
 
     private fun updateNotPresent(): Set<Mod> {
         return downloadURLs.filter { !it.key.isDownloaded }.keys.also { notPresentDownloads = it }
+    }
+
+    private fun configUpdateNotPresent(): Set<Mod> {
+        return downloadConfigURLs.filter { !it.key.isDownloaded }.keys.also { notPresentConfigDownloads = it }
     }
 }
 

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
@@ -39,6 +39,14 @@ class LaunchyState(
             .toMap()
         )
     }
+
+    val downloadConfigURLs = mutableStateMapOf<Mod, DownloadURL>().apply {
+        putAll(config.downloads
+            .mapNotNull { it.key.toMod()?.to(it.value) }
+            .toMap()
+        )
+    }
+
     var installedFabricVersion by mutableStateOf(config.installedFabricVersion)
 
     var notPresentDownloads by mutableStateOf(setOf<Mod>())
@@ -116,6 +124,13 @@ class LaunchyState(
             downloading -= mod
             downloadURLs[mod] = mod.url
             save()
+
+            if (mod.configUrl != null) {
+                Downloader.download(url = mod.configUrl, writeTo = Dirs.configZip)
+                downloadConfigURLs[mod] = mod.configUrl
+                unzip((Dirs.configZip).toFile(), Dirs.mineinabyss.toString())
+                (Dirs.configZip).toFile().delete()
+            }
         }.onFailure {
             scaffoldState.snackbarHostState.showSnackbar(
                 "Failed to download ${mod.name}: ${it.localizedMessage}!", "OK"

--- a/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/logic/LaunchyState.kt
@@ -94,8 +94,7 @@ class LaunchyState(
         }
     }
 
-
-    fun installFabric() {
+    suspend fun installFabric() {
         installingProfile = true
         FabricInstaller.installToLauncher(
             Dirs.minecraft,

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Link
+import androidx.compose.material.icons.rounded.Update
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,7 +31,7 @@ object Browser {
 fun ModInfo(group: Group, mod: Mod) {
     val state = LocalLaunchyState
     val modEnabled by derivedStateOf { mod in state.enabledMods }
-    val configEnabled by derivedStateOf { state.configToggleState }
+    val configEnabled by derivedStateOf { mod in state.enabledConfigs }
 
     var linkExpanded by remember { mutableStateOf(false) }
     val linkRotationState by animateFloatAsState(targetValue = if (linkExpanded) 180f else 0f)
@@ -85,28 +87,12 @@ fun ModInfo(group: Group, mod: Mod) {
                         )
                     }
                 if (mod.configUrl != null) {
-                    var isEnabled by remember { mutableStateOf(configEnabled) }
-                    IconButton(
-                        onClick = {
-                            if (!mod.forceConfigDownload) {
-                                state.configToggleState = !state.configToggleState
-                                isEnabled = state.configToggleState
-                            }
-                        }) {
-                        if (isEnabled && !mod.forceConfigDownload) {
-                            Icon(
-                                imageVector = Icons.Rounded.ToggleOn,
-                                contentDescription = "Config Download Enabled",
-                                modifier = Modifier.alpha(ContentAlpha.high),
-                            )
-                        } else {
-                            Icon(
-                                imageVector = Icons.Rounded.ToggleOff,
-                                contentDescription = "Config Download Disabled",
-                                modifier = Modifier.alpha(ContentAlpha.disabled),
-                            )
-                        }
-                    }
+                    Switch(
+                        enabled = !mod.forceConfigDownload,
+                        checked = configEnabled,
+                        onCheckedChange = { state.setModConfigEnabled(mod, !configEnabled) },
+
+                        )
                 }
             }
             AnimatedVisibility(linkExpanded) {

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
@@ -111,27 +111,40 @@ fun ModInfo(group: Group, mod: Mod) {
                 )
             }
             AnimatedVisibility(configExpanded) {
-                Text(
-                    "Toggle Config Download: ${mod.configUrl}",
-                    style = MaterialTheme.typography.subtitle1,
-                    fontSize = 12.sp
-                )
-                IconButton(
-                    onClick = { if (!mod.forceConfigDownload) state.setModConfigEnabled(mod, !configEnabled) }) {
-                    if (!configEnabled && !mod.forceConfigDownload) {
-                        Icon(
-                            imageVector = Icons.Rounded.ToggleOff,
-                            contentDescription = "Config Toggle",
-                            modifier = Modifier.alpha(ContentAlpha.disabled).size(40.dp)
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Rounded.ToggleOn,
-                            tint = Color.hsl(15F, 1F, 0.65F),
-                            contentDescription = "Config Toggle",
-                            modifier = Modifier.size(40.dp)
-                        )
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+                    IconButton(
+                        onClick = { if (!mod.forceConfigDownload) state.setModConfigEnabled(mod, !configEnabled) }) {
+                        if (!configEnabled && !mod.forceConfigDownload) {
+                            Icon(
+                                imageVector = Icons.Rounded.ToggleOff,
+                                contentDescription = "Config Toggle",
+                                modifier = Modifier.alpha(ContentAlpha.disabled).size(40.dp)
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Rounded.ToggleOn,
+                                tint = Color.hsl(15F, 1F, 0.65F),
+                                contentDescription = "Config Toggle",
+                                modifier = Modifier.size(40.dp)
+                            )
+                        }
                     }
+                    Text(
+                        "Toggle Config Download",
+                        style = MaterialTheme.typography.subtitle1,
+                        fontSize = 16.sp
+                    )
+
+//                    IconButton(
+//                        modifier = Modifier
+//                            .alpha(ContentAlpha.medium)
+//                            .rotate(linkRotationState),
+//                        onClick = { BrowserLauncher().openURLinBrowser(mod.configUrl) }) {
+//                        Icon(
+//                            imageVector = Icons.Rounded.Info,
+//                            contentDescription = "URL"
+//                        )
+//                    }
                 }
             }
         }

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
@@ -12,7 +12,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ExperimentalGraphicsApi
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.mineinabyss.launchy.LocalLaunchyState
 import com.mineinabyss.launchy.data.Group
 import com.mineinabyss.launchy.data.Mod
@@ -25,6 +28,7 @@ object Browser {
     fun browse(url: String) = synchronized(desktop) { desktop.browse(URI.create(url)) }
 }
 
+@OptIn(ExperimentalGraphicsApi::class)
 @Composable
 fun ModInfo(group: Group, mod: Mod) {
     val state = LocalLaunchyState
@@ -107,18 +111,23 @@ fun ModInfo(group: Group, mod: Mod) {
                 )
             }
             AnimatedVisibility(configExpanded) {
-                Text("Toggle Config Download: ", style = MaterialTheme.typography.caption)
+                Text(
+                    "Toggle Config Download: ${mod.configUrl}",
+                    style = MaterialTheme.typography.subtitle1,
+                    fontSize = 12.sp
+                )
                 IconButton(
                     onClick = { if (!mod.forceConfigDownload) state.setModConfigEnabled(mod, !configEnabled) }) {
                     if (!configEnabled && !mod.forceConfigDownload) {
                         Icon(
                             imageVector = Icons.Rounded.ToggleOff,
                             contentDescription = "Config Toggle",
-                            modifier = Modifier.alpha(ContentAlpha.medium).size(40.dp)
+                            modifier = Modifier.alpha(ContentAlpha.disabled).size(40.dp)
                         )
                     } else {
                         Icon(
                             imageVector = Icons.Rounded.ToggleOn,
+                            tint = Color.hsl(15F, 1F, 0.65F),
                             contentDescription = "Config Toggle",
                             modifier = Modifier.size(40.dp)
                         )

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Delete
-import androidx.compose.material.icons.rounded.Link
-import androidx.compose.material.icons.rounded.Update
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,6 +19,7 @@ import com.mineinabyss.launchy.data.Mod
 import edu.stanford.ejalbert.BrowserLauncher
 import java.awt.Desktop
 import java.net.URI
+
 object Browser {
     val desktop = Desktop.getDesktop()
     fun browse(url: String ) = synchronized(desktop) { desktop.browse(URI.create(url))}
@@ -30,6 +29,7 @@ object Browser {
 fun ModInfo(group: Group, mod: Mod) {
     val state = LocalLaunchyState
     val modEnabled by derivedStateOf { mod in state.enabledMods }
+    val configEnabled by derivedStateOf { state.configToggleState }
 
     var linkExpanded by remember { mutableStateOf(false) }
     val linkRotationState by animateFloatAsState(targetValue = if (linkExpanded) 180f else 0f)
@@ -84,6 +84,30 @@ fun ModInfo(group: Group, mod: Mod) {
                             contentDescription = "URL"
                         )
                     }
+                if (mod.configUrl != null) {
+                    var isEnabled by remember { mutableStateOf(configEnabled) }
+                    IconButton(
+                        onClick = {
+                            if (!mod.forceConfigDownload) {
+                                state.configToggleState = !state.configToggleState
+                                isEnabled = state.configToggleState
+                            }
+                        }) {
+                        if (isEnabled && !mod.forceConfigDownload) {
+                            Icon(
+                                imageVector = Icons.Rounded.ToggleOn,
+                                contentDescription = "Config Download Enabled",
+                                modifier = Modifier.alpha(ContentAlpha.high),
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Rounded.ToggleOff,
+                                contentDescription = "Config Download Disabled",
+                                modifier = Modifier.alpha(ContentAlpha.disabled),
+                            )
+                        }
+                    }
+                }
             }
             AnimatedVisibility(linkExpanded) {
                 Text(

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Delete
-import androidx.compose.material.icons.rounded.Link
-import androidx.compose.material.icons.rounded.Update
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,7 +22,7 @@ import java.net.URI
 
 object Browser {
     val desktop = Desktop.getDesktop()
-    fun browse(url: String ) = synchronized(desktop) { desktop.browse(URI.create(url))}
+    fun browse(url: String) = synchronized(desktop) { desktop.browse(URI.create(url)) }
 }
 
 @Composable
@@ -35,6 +33,9 @@ fun ModInfo(group: Group, mod: Mod) {
 
     var linkExpanded by remember { mutableStateOf(false) }
     val linkRotationState by animateFloatAsState(targetValue = if (linkExpanded) 180f else 0f)
+
+    var configExpanded by remember { mutableStateOf(false) }
+    val configTabState by animateFloatAsState(targetValue = if (configExpanded) 180f else 0f)
 
     Box(
         modifier = Modifier
@@ -87,12 +88,15 @@ fun ModInfo(group: Group, mod: Mod) {
                         )
                     }
                 if (mod.configUrl != null) {
-                    Switch(
-                        enabled = !mod.forceConfigDownload,
-                        checked = configEnabled,
-                        onCheckedChange = { state.setModConfigEnabled(mod, !configEnabled) },
-
+                    IconButton(
+                        modifier = Modifier.alpha(ContentAlpha.medium).rotate(configTabState),
+                        onClick = { if (!mod.forceConfigDownload) configExpanded = !configExpanded }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Settings,
+                            contentDescription = "ConfigTab"
                         )
+                    }
                 }
             }
             AnimatedVisibility(linkExpanded) {
@@ -101,6 +105,25 @@ fun ModInfo(group: Group, mod: Mod) {
                     style = MaterialTheme.typography.subtitle2,
                     modifier = Modifier.alpha(ContentAlpha.medium)
                 )
+            }
+            AnimatedVisibility(configExpanded) {
+                Text("Toggle Config Download: ", style = MaterialTheme.typography.caption)
+                IconButton(
+                    onClick = { if (!mod.forceConfigDownload) state.setModConfigEnabled(mod, !configEnabled) }) {
+                    if (!configEnabled && !mod.forceConfigDownload) {
+                        Icon(
+                            imageVector = Icons.Rounded.ToggleOff,
+                            contentDescription = "Config Toggle",
+                            modifier = Modifier.alpha(ContentAlpha.medium).size(40.dp)
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Rounded.ToggleOn,
+                            contentDescription = "Config Toggle",
+                            modifier = Modifier.size(40.dp)
+                        )
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/ModInfo.kt
@@ -19,9 +19,6 @@ import com.mineinabyss.launchy.LocalLaunchyState
 import com.mineinabyss.launchy.data.Group
 import com.mineinabyss.launchy.data.Mod
 import edu.stanford.ejalbert.BrowserLauncher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.awt.Desktop
 import java.net.URI
 object Browser {

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/MainScreen.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/MainScreen.kt
@@ -41,15 +41,20 @@ fun MainScreen() {
 
                     val coroutineScope = rememberCoroutineScope()
 
-                    Button(enabled = !state.isDownloading && operationsQueued && minecraftValid, onClick = {
-                        coroutineScope.launch { state.install() }
-                    }) {
+                    Button(
+                        enabled = !state.isDownloading && !state.installingProfile && operationsQueued && minecraftValid,
+                        onClick = {
+                            coroutineScope.launch { state.install() }
+                        }) {
                         Icon(Icons.Rounded.Download, "Download")
-                        AnimatedVisibility(!state.isDownloading) {
+                        AnimatedVisibility(!state.isDownloading && !state.installingProfile) {
                             Text("Install")
                         }
+                        AnimatedVisibility(state.installingProfile) {
+                            Text("Installing Profile...")
+                        }
                         AnimatedVisibility(state.isDownloading) {
-                            Text("Installing...")
+                            Text("Downloading mods...")
                         }
                     }
                     Spacer(Modifier.width(10.dp))


### PR DESCRIPTION
Downloads a configs.zip from launchy-mods when profile is being created.
Means it will only happen on the first time essentially as profile wont be remade on fabric or mod updates

Had to make most of the installFunctions suspend, might be a way to call installBaseConfig() within profileinstall without this tho