### PR TITLE
Progress bar & small ui element fixes

### DIFF
--- a/src/main/kotlin/com/mineinabyss/launchy/Main.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/Main.kt
@@ -24,6 +24,7 @@ import com.mineinabyss.launchy.ui.rememberMIAColorScheme
 import com.mineinabyss.launchy.ui.screens.Screens
 import com.mineinabyss.launchy.ui.state.TopBarProvider
 import com.mineinabyss.launchy.ui.state.TopBarState
+import com.mineinabyss.launchy.util.OS
 
 private val LaunchyStateProvider = compositionLocalOf<LaunchyState> { error("No local versions provided") }
 val LocalLaunchyState: LaunchyState
@@ -49,6 +50,7 @@ fun main() {
             icon = icon,
             onCloseRequest = onClose,
             undecorated = true,
+            transparent = OS.get() == OS.WINDOWS, // Windows 11 shows a white bar on the bottom without this
         ) {
             val topBarState = remember { TopBarState(onClose, windowState, this) }
             val ready = launchyState != null

--- a/src/main/kotlin/com/mineinabyss/launchy/data/Constants.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/data/Constants.kt
@@ -1,0 +1,5 @@
+package com.mineinabyss.launchy.data
+
+object Constants {
+    const val ENABLE_PLAY_BUTTON = false
+}

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/main/MainScreen.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/main/MainScreen.kt
@@ -46,8 +46,8 @@ fun MainScreen() {
                 Spacer(Modifier.width(10.dp))
                 AnimatedVisibility(state.operationsQueued) {
                     UpdateInfoButton()
+                    Spacer(Modifier.width(10.dp))
                 }
-                Spacer(Modifier.width(10.dp))
 //                NewsButton(hasUpdates = true)
 //                Spacer(Modifier.width(10.dp))
                 SettingsButton()

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/main/buttons/PlayButton.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/main/buttons/PlayButton.kt
@@ -5,17 +5,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import com.mineinabyss.launchy.LocalLaunchyState
+import com.mineinabyss.launchy.data.Constants
 import com.mineinabyss.launchy.ui.screens.main.showComingSoonDialog
 
 @Composable
 fun PlayButton(enabled: Boolean) {
     val state = LocalLaunchyState
-    val coroutineScope = rememberCoroutineScope()
 
     Button(
-        enabled = enabled,
+        enabled = Constants.ENABLE_PLAY_BUTTON && enabled,
         onClick = {
             showComingSoonDialog.value = true
         },

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/settings/InfoBar.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/settings/InfoBar.kt
@@ -29,7 +29,7 @@ fun InfoBar(modifier: Modifier = Modifier) {
             val totalBytesDownloaded =
                 state.downloading.values.sumOf { it.bytesDownloaded } + state.downloadingConfigs.values.sumOf { it.bytesDownloaded }
             LinearProgressIndicator(
-                progress = totalBytesDownloaded.toFloat() / totalBytesToDownload.toFloat(),
+                progress = if (totalBytesToDownload == 0L) 0f else totalBytesDownloaded.toFloat() / totalBytesToDownload,
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.primaryContainer
             )

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/settings/ModInfo.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/settings/ModInfo.kt
@@ -60,7 +60,7 @@ fun ModInfo(group: Group, mod: Mod) {
             val total = ((state.downloading[mod]?.totalBytes ?: 0L) + (state.downloadingConfigs[mod]?.totalBytes
                 ?: 0L)).toFloat()
             LinearProgressIndicator(
-                progress = downloaded / total,
+                progress = if (total == 0f) 0f else downloaded / total,
                 color = MaterialTheme.colorScheme.primaryContainer
             )
         }


### PR DESCRIPTION
* Set window as transparent on windows to fix issue with white line on Windows 11
* Disable play button
* Fix spacing of main menu buttons
* Fix division by zero in progress bar
* Mark legendary tooltips as incompatible with sodium (see https://github.com/CaffeineMC/sodium-fabric/issues/1602)