### PR TITLE
Install instances via Drag&Drop a .mrpack

### DIFF
--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/home/HomeScreen.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/home/HomeScreen.kt
@@ -29,9 +29,6 @@ fun HomeScreen() {
     Scaffold { paddingValues ->
         val scrollState = rememberLazyListState()
         BoxWithConstraints {
-            val showDragFileCard = remember { mutableStateOf(false) }
-            HandleFileDropping(showDragFileCard)
-            ShowDropFileCard(showDragFileCard)
             Column(Modifier.padding(end = 20.dp).fillMaxSize()) {
 //                var searchQuery by remember { mutableStateOf("") }
 //                SearchBar(
@@ -72,60 +69,6 @@ fun HomeScreen() {
                         hoverColor = MaterialTheme.colorScheme.primary
                     )
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun HandleFileDropping(showDragFileCard: MutableState<Boolean>) {
-    val state = LocalLaunchyState
-    val target = object : DropTarget() {
-        @Synchronized
-        override fun dragEnter(event: DropTargetDragEvent) {
-            val files = (event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>).filterIsInstance<File>()
-            if (files.any { it.extension == "mrpack" })
-                showDragFileCard.value = true
-            else event.rejectDrag()
-        }
-
-        @Synchronized
-        override fun dragExit(event: DropTargetEvent) {
-            showDragFileCard.value = false
-        }
-
-        @Synchronized
-        override fun drop(event: DropTargetDropEvent) {
-            showDragFileCard.value = false
-            runCatching {
-                event.acceptDrop(DnDConstants.ACTION_REFERENCE)
-                val files = (event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>).filterIsInstance<File>()
-                files.firstOrNull { it.extension == "mrpack" }?.let {
-                    //TODO This does not work as GameInstanceConfig#read doesnt properly deserialize .mrpack
-                    //GameInstance.create(state, GameInstanceConfig.read(it.toPath()))
-                }
-            }.onFailure {
-                it.printStackTrace()
-            }
-        }
-    }
-    windowScope.window.dropTarget = target
-}
-
-@Composable
-private fun ShowDropFileCard(showDragFileCard: MutableState<Boolean>) {
-    if (!showDragFileCard.value) return
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background.copy(alpha = 0.5f)
-    ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            Row {
-                Icon(Icons.Rounded.FileUpload, contentDescription = "Upload")
-                Text("Drop a .mrpack to create an instance...", style = MaterialTheme.typography.bodyLarge)
             }
         }
     }

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/home/HomeScreen.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/home/HomeScreen.kt
@@ -6,12 +6,21 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.FileUpload
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mineinabyss.launchy.LocalLaunchyState
+import com.mineinabyss.launchy.ui.state.windowScope
+import java.awt.datatransfer.DataFlavor
+import java.awt.dnd.*
+import java.io.File
 
 @Composable
 fun HomeScreen() {
@@ -20,6 +29,9 @@ fun HomeScreen() {
     Scaffold { paddingValues ->
         val scrollState = rememberLazyListState()
         BoxWithConstraints {
+            val showDragFileCard = remember { mutableStateOf(false) }
+            HandleFileDropping(showDragFileCard)
+            ShowDropFileCard(showDragFileCard)
             Column(Modifier.padding(end = 20.dp).fillMaxSize()) {
 //                var searchQuery by remember { mutableStateOf("") }
 //                SearchBar(
@@ -65,3 +77,56 @@ fun HomeScreen() {
     }
 }
 
+@Composable
+private fun HandleFileDropping(showDragFileCard: MutableState<Boolean>) {
+    val state = LocalLaunchyState
+    val target = object : DropTarget() {
+        @Synchronized
+        override fun dragEnter(event: DropTargetDragEvent) {
+            val files = (event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>).filterIsInstance<File>()
+            if (files.any { it.extension == "mrpack" })
+                showDragFileCard.value = true
+            else event.rejectDrag()
+        }
+
+        @Synchronized
+        override fun dragExit(event: DropTargetEvent) {
+            showDragFileCard.value = false
+        }
+
+        @Synchronized
+        override fun drop(event: DropTargetDropEvent) {
+            showDragFileCard.value = false
+            runCatching {
+                event.acceptDrop(DnDConstants.ACTION_REFERENCE)
+                val files = (event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>).filterIsInstance<File>()
+                files.firstOrNull { it.extension == "mrpack" }?.let {
+                    //TODO This does not work as GameInstanceConfig#read doesnt properly deserialize .mrpack
+                    //GameInstance.create(state, GameInstanceConfig.read(it.toPath()))
+                }
+            }.onFailure {
+                it.printStackTrace()
+            }
+        }
+    }
+    windowScope.window.dropTarget = target
+}
+
+@Composable
+private fun ShowDropFileCard(showDragFileCard: MutableState<Boolean>) {
+    if (!showDragFileCard.value) return
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background.copy(alpha = 0.5f)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Row {
+                Icon(Icons.Rounded.FileUpload, contentDescription = "Upload")
+                Text("Drop a .mrpack to create an instance...", style = MaterialTheme.typography.bodyLarge)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mineinabyss/launchy/ui/screens/home/ModpackGroup.kt
+++ b/src/main/kotlin/com/mineinabyss/launchy/ui/screens/home/ModpackGroup.kt
@@ -23,7 +23,7 @@ fun ModpackGroup(title: String, packs: List<GameInstance>) {
         Spacer(Modifier.height(8.dp))
         BoxWithConstraints(Modifier) {
             val total = packs.size + 1
-            val colums = ((maxWidth / ModpackCardStyle.cardWidth).toInt()).coerceAtMost(total).coerceAtLeast(1)
+            val colums = ((maxWidth / ModpackCardStyle.cardWidth).toInt()).coerceIn(1..total)
             val rows = (total / colums).coerceAtLeast(1)
             val lazyGridState = rememberLazyGridState()
             LazyVerticalGrid(


### PR DESCRIPTION
Implements convenient way to import an instance from a modrinth modpack
Unsure on the structure due to tons of new reworks since last i touched Launchy, but yeah logic is there

Currently only the drag&drop funcitonality works, deserializing it to a GameInstance does not
This does come with a few downsides as backgroundUrl and logoUrl etc are not included in the mrpack
However this could be gotten from Modrinth via Labrinth API as we have the project

https://github.com/MineInAbyss/launchy/assets/62521371/207d0cd9-cd48-4b97-a466-c76dff27afe2

